### PR TITLE
Replace Masuit.Tools INI/crypto with SoftCircuits.IniFileParser and DPAPI; robust INI handling

### DIFF
--- a/ATC4-HQ.csproj
+++ b/ATC4-HQ.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
@@ -28,7 +28,8 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Masuit.Tools.Net" Version="2025.4.4" />
+    <PackageReference Include="SoftCircuits.IniFileParser" Version="3.0.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.10" />
     <PackageReference Include="MonoTorrent" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />

--- a/ATC4-HQ.csproj
+++ b/ATC4-HQ.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="SoftCircuits.IniFileParser" Version="3.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.10" />
+    <PackageReference Include="System.Management" Version="9.0.10" />
     <PackageReference Include="MonoTorrent" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [eazyx](https://easyx.cn/)
 
 [python](https://www.python.org/)
+
+[Masuit.Tools](https://github.com/ldqk/Masuit.Tools)
 > [!WARNING]
 > 以上库已经在最新版本被移除
 
@@ -16,7 +18,7 @@
 - 抄的UI和部分代码
 </br>
 
-[Masuit.Tools](https://github.com/ldqk/Masuit.Tools)
+[SoftCircuits.IniFileParser](https://www.nuget.org/packages/SoftCircuits.IniFileParser/)
 
 [Avalonia](https://avaloniaui.net/)
 

--- a/ViewModels/AllGameListViewModel.cs
+++ b/ViewModels/AllGameListViewModel.cs
@@ -1,7 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
-using Masuit.Tools.Files;
+using SoftCircuits.IniFileParser;
 using master.Globals;
+using System.IO;
 
 namespace ATC4_HQ.ViewModels;
 
@@ -25,8 +26,13 @@ public class AllGameListViewModel : ObservableObject
     public AllGameListViewModel()
     {
         //从配置文件找要显示的东西
-        IniFile ini = new IniFile(GlobalPaths.GamePath + @"\GameData.ini");
-        var GameName = ini.GetValue("GameSettings", "GameName");
+        var gameDataIniPath = GlobalPaths.GamePath + @"\GameData.ini";
+        IniFile ini = new IniFile();
+        if (File.Exists(gameDataIniPath))
+        {
+            ini.Load(gameDataIniPath);
+        }
+        var GameName = ini.GetSetting("GameSettings", "GameName", string.Empty) ?? string.Empty;
                 
         //显示的内容
         AllGames = new ObservableCollection<string>

--- a/ViewModels/GameListViewModel.cs
+++ b/ViewModels/GameListViewModel.cs
@@ -1,6 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
-using Masuit.Tools.Files;
+using SoftCircuits.IniFileParser;
 using master.Globals;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
@@ -50,21 +50,21 @@ public partial class GameListViewModel : ViewModelBase
     public GameListViewModel()
     {
         //从配置文件找要显示的东西
-        IniFile ini = new IniFile(GlobalPaths.InitiatorProfileName);
+        IniFile ini = new IniFile();
+        if (File.Exists(GlobalPaths.InitiatorProfileName))
+        {
+            ini.Load(GlobalPaths.InitiatorProfileName);
+        }
         var games = new ObservableCollection<GameInfo>();
         
         //读取游戏目录配置
-        var gameDirs = ini.GetSection("GameDirectories");
-        if (gameDirs != null)
+        foreach (var setting in ini.GetSectionSettings("GameDirectories"))
         {
-            foreach (var key in gameDirs.Keys)
+            var path = setting.Value;
+            if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
             {
-                var path = gameDirs[key];
-                if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
-                {
-                    var gameName = Path.GetFileName(path);
-                    games.Add(new GameInfo { Name = gameName, Path = path });
-                }
+                var gameName = Path.GetFileName(path);
+                games.Add(new GameInfo { Name = gameName, Path = path });
             }
         }
         

--- a/ViewModels/LEInstallViewModel.cs
+++ b/ViewModels/LEInstallViewModel.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.IO.Compression;
+using SoftCircuits.IniFileParser;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -147,9 +148,13 @@ namespace ATC4_HQ.ViewModels
                         
                         // 保存到配置文件
                         LoggerHelper.LogInformation("[LE安装] 保存配置到INI文件...");
-                        var iniFile = new Masuit.Tools.Files.IniFile(master.Globals.GlobalPaths.InitiatorProfileName);
-                        iniFile.SetValue("main", "TransitSoftwareLE", master.Globals.GlobalPaths.TransitSoftwareLE);
-                        iniFile.Save();
+                        var iniFile = new IniFile();
+                        if (File.Exists(master.Globals.GlobalPaths.InitiatorProfileName))
+                        {
+                            iniFile.Load(master.Globals.GlobalPaths.InitiatorProfileName);
+                        }
+                        iniFile.SetSetting("main", "TransitSoftwareLE", master.Globals.GlobalPaths.TransitSoftwareLE ?? string.Empty);
+                        iniFile.Save(master.Globals.GlobalPaths.InitiatorProfileName);
                         LoggerHelper.LogInformation("[LE安装] 配置文件保存完成");
                         
                         InstallStatus = $"安装完成！已保存到: {targetPath}";

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Threading.Tasks;
@@ -6,7 +6,7 @@ using System.Windows.Input;
 using ATC4_HQ.Models; // 引入 GameModel 的命名空间
 using System.IO.Compression; // 用于解压缩功能
 using master.Globals;
-using Masuit.Tools.Files;
+using SoftCircuits.IniFileParser;
 using System.IO; // 用于检查文件是否存在
 using System.Collections.Generic; // 用于Stack
 
@@ -288,13 +288,23 @@ namespace ATC4_HQ.ViewModels
             }
 
             GlobalPaths.GamePath = gameData.Path; // 更新全局路径
-            IniFile ini = new IniFile(GlobalPaths.InitiatorProfileName);
-            ini.SetValue("main", "GamePath", GlobalPaths.GamePath);
-            ini.Save();
+            IniFile ini = new IniFile();
+            if (File.Exists(GlobalPaths.InitiatorProfileName))
+            {
+                ini.Load(GlobalPaths.InitiatorProfileName);
+            }
+            ini.SetSetting("main", "GamePath", GlobalPaths.GamePath ?? string.Empty);
+            ini.Save(GlobalPaths.InitiatorProfileName);
+
             GlobalPaths.GameName = gameData.Name;
-            ini = new IniFile(GlobalPaths.GamePath + @"\GameData.ini");
-            ini.SetValue("GameSettings" , "GameName" , GlobalPaths.GameName);
-            ini.Save();
+            var gameDataIniPath = GlobalPaths.GamePath + @"\GameData.ini";
+            ini = new IniFile();
+            if (File.Exists(gameDataIniPath))
+            {
+                ini.Load(gameDataIniPath);
+            }
+            ini.SetSetting("GameSettings", "GameName", GlobalPaths.GameName ?? string.Empty);
+            ini.Save(gameDataIniPath);
             
             // 安装完成后清除右边区域的内容
             ClearSubPage();

--- a/ViewModels/SettingViewModel.cs
+++ b/ViewModels/SettingViewModel.cs
@@ -1,9 +1,10 @@
 using System;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Windows.Input;
 using master.Globals;
-using Masuit.Tools.Files;
+using SoftCircuits.IniFileParser;
 using Avalonia.Controls;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -22,7 +23,11 @@ public partial class SettingViewModel : ViewModelBase
 
     public SettingViewModel()
     {
-        _ini = new IniFile(GlobalPaths.InitiatorProfileName);
+        _ini = new IniFile();
+        if (File.Exists(GlobalPaths.InitiatorProfileName))
+        {
+            _ini.Load(GlobalPaths.InitiatorProfileName);
+        }
         _LE_address = GlobalPaths.TransitSoftwareLE;
         if (_LE_address == null)
         {
@@ -51,8 +56,8 @@ public partial class SettingViewModel : ViewModelBase
     private void SaveSetting()
     {
         GlobalPaths.TransitSoftwareLE = LE_address;
-        _ini.SetValue("main", "TransitSoftwareLE", GlobalPaths.TransitSoftwareLE);
-        _ini.Save();
+        _ini.SetSetting("main", "TransitSoftwareLE", GlobalPaths.TransitSoftwareLE ?? string.Empty);
+        _ini.Save(GlobalPaths.InitiatorProfileName);
         LoggerHelper.LogInformation($"设置已保存。{GlobalPaths.TransitSoftwareLE}");
     }
 

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -7,8 +7,8 @@ using ATC4_HQ.Models; // ⭐️ 新增：引入 GameModel 的命名空间
 using master.Globals;
 using System.IO;
 using System.Text;
-using Masuit.Tools.Security;
-using Masuit.Tools.Files;
+using System.Security.Cryptography;
+using SoftCircuits.IniFileParser;
 using System.Threading.Tasks; // 添加Task支持
 using Avalonia;
 using Avalonia.Media;
@@ -176,18 +176,19 @@ namespace ATC4_HQ.Views
                 return;
             }
             LoggerHelper.LogInformation("配置文件存在，正在加载...");
-            IniFile ini = new IniFile(GlobalPaths.InitiatorProfileName);
-            var PrimaryProfileVersion = ini.GetValue("main", "Version");
+            IniFile ini = new IniFile();
+            ini.Load(GlobalPaths.InitiatorProfileName);
+            var PrimaryProfileVersion = ini.GetSetting("main", "Version", string.Empty);
             if (PrimaryProfileVersion != GlobalPaths.Version)
             {
                 LoggerHelper.LogWarning($"配置文件版本不匹配，当前版本：{GlobalPaths.Version}，配置文件版本：{PrimaryProfileVersion}");
                 return;
             }
-            GlobalPaths.TransitSoftwareLE = ini.GetValue("main", "TransitSoftwareLE");
-            GlobalPaths.GamePath = ini.GetValue("main", "GamePath");
+            GlobalPaths.TransitSoftwareLE = ini.GetSetting("main", "TransitSoftwareLE", string.Empty);
+            GlobalPaths.GamePath = ini.GetSetting("main", "GamePath", string.Empty);
 
             // 读取BT配置，默认为false
-            string btEnabledValue = ini.GetValue("main", "BTEnabled");
+            string btEnabledValue = ini.GetSetting("main", "BTEnabled", string.Empty) ?? string.Empty;
             if (bool.TryParse(btEnabledValue, out bool btEnabled))
             {
                 GlobalPaths.BTEnabled = btEnabled;
@@ -210,20 +211,24 @@ namespace ATC4_HQ.Views
             LoggerHelper.LogDebug($"当前时间：{generalShort}");
 
             // 获取加密时间
-            string encryptedText = generalShort.AESEncrypt(GlobalPaths.Keys);;
+            byte[] encryptedBytes = ProtectedData.Protect(
+                Encoding.UTF8.GetBytes(generalShort),
+                Encoding.UTF8.GetBytes(GlobalPaths.Keys),
+                DataProtectionScope.CurrentUser);
+            string encryptedText = Convert.ToBase64String(encryptedBytes);
             LoggerHelper.LogDebug($"加密后的时间：{encryptedText}");
 
             //返回值
             GlobalPaths.FirstRun = encryptedText;
 
             LoggerHelper.LogInformation("创建初始配置文件...");
-            IniFile ini=new IniFile(GlobalPaths.InitiatorProfileName);
-            ini.SetValue("main", "Version", GlobalPaths.Version);
-            ini.SetValue("main", "FirstRun", GlobalPaths.FirstRun);
-            ini.SetValue("main", "TransitSoftwareLE" , "null");
-            ini.SetValue("main", "BTEnabled", "false");
+            IniFile ini = new IniFile();
+            ini.SetSetting("main", "Version", GlobalPaths.Version);
+            ini.SetSetting("main", "FirstRun", GlobalPaths.FirstRun ?? string.Empty);
+            ini.SetSetting("main", "TransitSoftwareLE", "null");
+            ini.SetSetting("main", "BTEnabled", "false");
             LoggerHelper.LogInformation("初始配置文件已创建。");
-            ini.Save();
+            ini.Save(GlobalPaths.InitiatorProfileName);
         }
         
         /// <summary>
@@ -430,9 +435,13 @@ namespace ATC4_HQ.Views
         {
             try
             {
-                IniFile ini = new IniFile(GlobalPaths.InitiatorProfileName);
-                ini.SetValue("main", "BTEnabled", enabled.ToString());
-                ini.Save();
+                IniFile ini = new IniFile();
+                if (File.Exists(GlobalPaths.InitiatorProfileName))
+                {
+                    ini.Load(GlobalPaths.InitiatorProfileName);
+                }
+                ini.SetSetting("main", "BTEnabled", enabled.ToString());
+                ini.Save(GlobalPaths.InitiatorProfileName);
                 LoggerHelper.LogInformation($"BT配置已保存: {enabled}");
             }
             catch (Exception ex)


### PR DESCRIPTION
### Motivation
- Remove dependency on `Masuit.Tools` and migrate INI parsing to a maintained NuGet package. 
- Use the platform data protection API instead of custom AES helper for simple secure values. 
- Make INI read/write operations more robust by explicitly loading/saving files and checking file existence. 
- Update documentation to reflect the removed library and new INI library.

### Description
- Updated project dependencies in `ATC4-HQ.csproj` to remove `Masuit.Tools.Net` and add `SoftCircuits.IniFileParser` and `System.Security.Cryptography.ProtectedData`.
- Updated `README.md` to remove the removed library from the list and add a link to `SoftCircuits.IniFileParser` while noting the removal.
- Replaced usages of `Masuit.Tools.Files.IniFile` across multiple view models and views with `SoftCircuits.IniFileParser.IniFile`, switching to the `Load`, `GetSetting` / `SetSetting`, and `Save(path)` APIs.
- Added file existence checks (`File.Exists`) before loading INI files and adjusted all save calls to pass the target filename to `Save`.
- Replaced custom AES encryption call with Windows DPAPI calls via `ProtectedData.Protect` and base64 encoding in `MainWindow.PrimaryProfile`.
- Adjusted game directory enumeration to use `ini.GetSectionSettings("GameDirectories")` and iterate settings to build the game list.
- Added necessary `using` imports such as `System.IO` and `System.Security.Cryptography` where required.

### Testing
- Ran `dotnet restore` to update packages and dependencies, which completed successfully.
- Ran `dotnet build`, which completed successfully with no compile errors after the API migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0810f095988324ba7b10296fc07718)

## Summary by Sourcery

将旧版的 Masuit.Tools INI 和加密方案替换为 SoftCircuits.IniFileParser 与基于 DPAPI 的保护机制，同时使配置文件的处理更加健壮。

Bug Fixes:
- 通过在读写 INI 文件前检查文件是否存在，并在加载或保存前初始化空的 INI 实例，防止出错。

Enhancements:
- 将各个视图和视图模型中的所有 INI 配置访问迁移到 SoftCircuits.IniFileParser，使用显式的 Load/Save 路径并提供更安全的默认值。
- 将主配置档案时间戳加密从自定义 AES 助手切换为使用 Windows DPAPI，并通过 base64 编码存储受保护数据。
- 通过迭代 INI 段的设置并在使用前验证路径，改进游戏目录和游戏数据的加载。
- 更新设置持久化逻辑，使配置更改始终通过新的 API 回写到主 INI 文件中。

Build:
- 更新项目依赖，移除 Masuit.Tools.Net，添加 SoftCircuits.IniFileParser 和 System.Security.Cryptography.ProtectedData。

Documentation:
- 更新 README，说明已移除 Masuit.Tools，并改为参考 SoftCircuits.IniFileParser。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the legacy Masuit.Tools INI and encryption usage with SoftCircuits.IniFileParser and DPAPI-based protection while making configuration file handling more robust.

Bug Fixes:
- Prevent errors when reading or writing INI files by checking for file existence and initializing empty INI instances before loading or saving.

Enhancements:
- Migrate all INI configuration access across views and view models to SoftCircuits.IniFileParser with explicit Load/Save paths and safer default values.
- Switch primary profile timestamp encryption from a custom AES helper to Windows DPAPI with base64 encoding for storing protected data.
- Improve game directory and game data loading by iterating INI section settings and validating paths before use.
- Update settings persistence to consistently write configuration changes back to the main INI file using the new API.

Build:
- Update project dependencies to remove Masuit.Tools.Net and add SoftCircuits.IniFileParser and System.Security.Cryptography.ProtectedData.

Documentation:
- Update README to note removal of Masuit.Tools and reference SoftCircuits.IniFileParser instead.

</details>