### PR TITLE
Extract DPAPI config protection helper

### DIFF
--- a/ConfigProtector.cs
+++ b/ConfigProtector.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ATC4_HQ
+{
+    /// <summary>
+    /// Provides DPAPI-based protection for configuration values.
+    /// </summary>
+    public static class ConfigProtector
+    {
+        /// <summary>
+        /// Protects a plain-text configuration value and returns it as Base64 text.
+        /// </summary>
+        /// <param name="plainText">The value to protect.</param>
+        /// <param name="entropy">Optional additional entropy used by DPAPI.</param>
+        /// <returns>The protected value encoded as Base64 text.</returns>
+        public static string Protect(string plainText, string? entropy = null)
+        {
+            ArgumentNullException.ThrowIfNull(plainText);
+
+            byte[] encryptedBytes = ProtectedData.Protect(
+                Encoding.UTF8.GetBytes(plainText),
+                GetEntropyBytes(entropy),
+                DataProtectionScope.CurrentUser);
+
+            return Convert.ToBase64String(encryptedBytes);
+        }
+
+        /// <summary>
+        /// Unprotects a Base64-encoded configuration value and returns the plain text.
+        /// </summary>
+        /// <param name="protectedText">The Base64-encoded protected value.</param>
+        /// <param name="entropy">Optional additional entropy used by DPAPI.</param>
+        /// <returns>The unprotected plain-text value.</returns>
+        public static string Unprotect(string protectedText, string? entropy = null)
+        {
+            ArgumentNullException.ThrowIfNull(protectedText);
+
+            byte[] decryptedBytes = ProtectedData.Unprotect(
+                Convert.FromBase64String(protectedText),
+                GetEntropyBytes(entropy),
+                DataProtectionScope.CurrentUser);
+
+            return Encoding.UTF8.GetString(decryptedBytes);
+        }
+
+        private static byte[]? GetEntropyBytes(string? entropy)
+        {
+            return string.IsNullOrEmpty(entropy) ? null : Encoding.UTF8.GetBytes(entropy);
+        }
+    }
+}

--- a/ConfigProtector.cs
+++ b/ConfigProtector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -28,6 +29,33 @@ namespace ATC4_HQ
         }
 
         /// <summary>
+        /// Attempts to protect a plain-text configuration value without surfacing expected crypto failures as exceptions.
+        /// </summary>
+        /// <param name="plainText">The value to protect.</param>
+        /// <param name="protectedText">The protected value encoded as Base64 text, or <c>null</c> when protection fails.</param>
+        /// <param name="entropy">Optional additional entropy used by DPAPI.</param>
+        /// <returns><c>true</c> when protection succeeds; otherwise, <c>false</c>.</returns>
+        public static bool TryProtect(string? plainText, [NotNullWhen(true)] out string? protectedText, string? entropy = null)
+        {
+            protectedText = null;
+
+            if (plainText is null)
+            {
+                return false;
+            }
+
+            try
+            {
+                protectedText = Protect(plainText, entropy);
+                return true;
+            }
+            catch (CryptographicException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Unprotects a Base64-encoded configuration value and returns the plain text.
         /// </summary>
         /// <param name="protectedText">The Base64-encoded protected value.</param>
@@ -45,9 +73,45 @@ namespace ATC4_HQ
             return Encoding.UTF8.GetString(decryptedBytes);
         }
 
+        /// <summary>
+        /// Attempts to unprotect a Base64-encoded configuration value without surfacing expected parsing or crypto failures as exceptions.
+        /// </summary>
+        /// <param name="protectedText">The Base64-encoded protected value.</param>
+        /// <param name="plainText">The unprotected plain-text value, or <c>null</c> when unprotection fails.</param>
+        /// <param name="entropy">Optional additional entropy used by DPAPI.</param>
+        /// <returns><c>true</c> when unprotection succeeds; otherwise, <c>false</c>.</returns>
+        public static bool TryUnprotect(string? protectedText, [NotNullWhen(true)] out string? plainText, string? entropy = null)
+        {
+            plainText = null;
+
+            if (protectedText is null)
+            {
+                return false;
+            }
+
+            try
+            {
+                plainText = Unprotect(protectedText, entropy);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+            catch (CryptographicException)
+            {
+                return false;
+            }
+        }
+
         private static byte[]? GetEntropyBytes(string? entropy)
         {
-            return string.IsNullOrEmpty(entropy) ? null : Encoding.UTF8.GetBytes(entropy);
+            if (entropy is null)
+            {
+                return null;
+            }
+
+            return entropy.Length == 0 ? Array.Empty<byte>() : Encoding.UTF8.GetBytes(entropy);
         }
     }
 }

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -7,7 +7,6 @@ using ATC4_HQ.Models; // ⭐️ 新增：引入 GameModel 的命名空间
 using master.Globals;
 using System.IO;
 using System.Text;
-using System.Security.Cryptography;
 using SoftCircuits.IniFileParser;
 using System.Threading.Tasks; // 添加Task支持
 using Avalonia;
@@ -211,11 +210,7 @@ namespace ATC4_HQ.Views
             LoggerHelper.LogDebug($"当前时间：{generalShort}");
 
             // 获取加密时间
-            byte[] encryptedBytes = ProtectedData.Protect(
-                Encoding.UTF8.GetBytes(generalShort),
-                Encoding.UTF8.GetBytes(GlobalPaths.Keys),
-                DataProtectionScope.CurrentUser);
-            string encryptedText = Convert.ToBase64String(encryptedBytes);
+            string encryptedText = ATC4_HQ.ConfigProtector.Protect(generalShort, GlobalPaths.Keys);
             LoggerHelper.LogDebug($"加密后的时间：{encryptedText}");
 
             //返回值

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -210,7 +210,12 @@ namespace ATC4_HQ.Views
             LoggerHelper.LogDebug($"当前时间：{generalShort}");
 
             // 获取加密时间
-            string encryptedText = ATC4_HQ.ConfigProtector.Protect(generalShort, GlobalPaths.Keys);
+            if (!ATC4_HQ.ConfigProtector.TryProtect(generalShort, out string? encryptedText, GlobalPaths.Keys))
+            {
+                LoggerHelper.LogError("加密初始配置时间失败，已取消创建初始配置文件。");
+                return;
+            }
+
             LoggerHelper.LogDebug($"加密后的时间：{encryptedText}");
 
             //返回值


### PR DESCRIPTION
### Motivation

- 将 `PrimaryProfile` 中内联的 DPAPI 加密逻辑提取为可复用工具，以便集中维护和在其他地方复用加解密功能。

### Description

- 添加 `ConfigProtector` 工具类（`ConfigProtector.cs`），提供基于 DPAPI 的 `Protect` 和 `Unprotect` 方法，统一处理 UTF-8 编码与 Base64 转换并支持可选 entropy。 
- 将 `Views/MainWindow.axaml.cs` 中原先直接使用 `ProtectedData.Protect(...)` 的代码替换为 `ATC4_HQ.ConfigProtector.Protect(generalShort, GlobalPaths.Keys)`。 
- 从视图文件中移除了对 `System.Security.Cryptography` 的直接引用，使视图只负责调用高层 API。 

### Testing

- 运行 `git diff --check`，检查未发现问题且通过. 
- 试图运行 `dotnet build ATC4-HQ.sln`，但构建未执行因为运行环境中未安装 `dotnet`（`dotnet: command not found`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081d7a810c8324bdfd7895f189bca1)

## Summary by Sourcery

将基于 DPAPI 的通用配置保护逻辑抽取为可复用的辅助工具，并在主窗口的配置文件逻辑中采用该工具。

New Features:
- 引入 `ConfigProtector` 工具类，为配置值提供基于 DPAPI 的 `Protect` 和 `Unprotect` 辅助方法。

Enhancements:
- 重构 MainWindow 中的 `PrimaryProfile`，使其使用 `ConfigProtector` 辅助工具替代内联的 DPAPI 调用，从而将视图层中对加密库的直接依赖移除。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract shared DPAPI-based configuration protection into a reusable helper and adopt it in the main window profile logic.

New Features:
- Introduce a ConfigProtector utility class providing DPAPI-based Protect and Unprotect helpers for configuration values.

Enhancements:
- Refactor PrimaryProfile in MainWindow to use the ConfigProtector helper instead of inline DPAPI calls, removing direct cryptography dependencies from the view layer.

</details>