### PR TITLE
Target Windows framework (net9.0-windows)

### DIFF
--- a/ATC4-HQ.csproj
+++ b/ATC4-HQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -10,6 +10,7 @@
     <PublishTrimmed>false</PublishTrimmed>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- 消除对仅在 Windows 上受支持的 API（例如 `ProtectedData`、`DataProtectionScope.CurrentUser`、`Registry.LocalMachine`）的跨平台调用分析警告，并明确此应用仅面向 Windows 平台。 

### Description
- 将项目 `TargetFramework` 从 `net9.0` 修改为 `net9.0-windows`，并添加 `EnableWindowsTargeting=true` 以支持在非 Windows 环境中评估 Windows TFM。 

### Testing
- 尝试运行 `dotnet build` 以执行自动构建但失败，原因是运行环境中未安装 `dotnet` CLI（`/bin/bash: line 1: dotnet: command not found`），因此无法在此环境完成自动构建验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081e7f69fc83248280187c20c69b8c)

## Summary by Sourcery

Build:
- 将项目目标框架从 `net9.0` 更改为 `net9.0-windows`，并为构建启用特定于 Windows 的目标设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Change the project target framework from net9.0 to net9.0-windows and enable Windows-specific targeting for builds.

</details>