### PR TITLE
ci: inject release version metadata into build outputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest # 在最新的 Windows 环境下运行
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
 
     steps:
     - name: Checkout code # 步骤1: 检出仓库代码
@@ -20,11 +22,23 @@ jobs:
     - name: Restore dependencies # 步骤3: 恢复 NuGet 包依赖
       run: dotnet restore ./ATC4-HQ.csproj # 修复路径：假设 ATC4-HQ 文件夹在仓库根目录
 
+    - name: Extract build version from release tag
+      run: |
+        $tagVersion = "${{ env.RELEASE_TAG }}"
+        if ([string]::IsNullOrWhiteSpace($tagVersion)) {
+          $appVersion = "0.0.0"
+        } else {
+          $appVersion = $tagVersion -replace '^[vV]', ''
+        }
+
+        echo "APP_VERSION=$appVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "Build version: $appVersion"
+
     - name: Build project # 步骤4: 构建项目 (Release 配置)
-      run: dotnet build ./ATC4-HQ.csproj --configuration Release --no-restore # 修复路径
+      run: dotnet build ./ATC4-HQ.csproj --configuration Release --no-restore /p:Version=${{ env.APP_VERSION }} /p:AssemblyVersion=${{ env.APP_VERSION }} /p:FileVersion=${{ env.APP_VERSION }} /p:InformationalVersion=${{ env.APP_VERSION }} # 修复路径
 
     - name: Publish application # 步骤5: 发布应用程序 (生成可执行文件)
-      run: dotnet publish ./ATC4-HQ.csproj --configuration Release --no-build -o publish # 修复路径
+      run: dotnet publish ./ATC4-HQ.csproj --configuration Release --no-build -o publish /p:Version=${{ env.APP_VERSION }} /p:AssemblyVersion=${{ env.APP_VERSION }} /p:FileVersion=${{ env.APP_VERSION }} /p:InformationalVersion=${{ env.APP_VERSION }} # 修复路径
 
     - name: Upload build artifact # 步骤6: 上传构建产物 (publish目录)
       uses: actions/upload-artifact@v4

--- a/Globals.cs
+++ b/Globals.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace master
 {
@@ -7,13 +8,28 @@ namespace master
         public static class GlobalPaths
         {
             public static string InitiatorProfileName = @".\ATC4-HQ.ini";
-            public static string Version = "1.5.0";
+            public static string Version = GetAppVersion();
             public static string? TransitSoftwareLE;
             public static string? FirstRun;
             public static string Keys = "0x5A";
             public static string? GamePath;
             public static string? GameName;
             public static string LogPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ATC4-HQ", "logs");
+
+            private static string GetAppVersion()
+            {
+                var informationalVersion = Assembly.GetExecutingAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion;
+
+                if (!string.IsNullOrWhiteSpace(informationalVersion))
+                {
+                    return informationalVersion.Split('+')[0];
+                }
+
+                var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version;
+                return assemblyVersion?.ToString() ?? "0.0.0";
+            }
         }
     }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -66,8 +66,8 @@ namespace ATC4_HQ.ViewModels
 
         public async Task CheckForUpdatesAsync()
         {
-            const string latestReleaseApi = "https://api.github.com/repos/Sjshi763/PicaComic/releases/latest";
-            const string releasesPage = "https://github.com/Sjshi763/PicaComic/releases";
+            const string latestReleaseApi = "https://api.github.com/repos/Sjshi763/ATC4-HQ/releases/latest";
+            const string releasesPage = "https://github.com/Sjshi763/ATC4-HQ/releases";
 
             try
             {

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -9,6 +9,8 @@ using master.Globals;
 using SoftCircuits.IniFileParser;
 using System.IO; // 用于检查文件是否存在
 using System.Collections.Generic; // 用于Stack
+using System.Net.Http;
+using System.Text.Json;
 
 namespace ATC4_HQ.ViewModels
 {
@@ -41,6 +43,9 @@ namespace ATC4_HQ.ViewModels
         // 事件：当需要显示OPENAL安装界面时触发
         public event EventHandler? ShowOpenALInstallView;
         
+        // 事件：当检测到有新版本时触发（由 View 层决定是否弹窗与后续操作）
+        public event EventHandler<UpdateAvailableEventArgs>? UpdateAvailable;
+        
         public ICommand StartGameCommand { get; }
         public ICommand InstallGameCommand { get; } // 用于 ViewModel 内部逻辑或未来绑定
         public ICommand SettingCommand { get; }
@@ -57,6 +62,52 @@ namespace ATC4_HQ.ViewModels
             
             // 初始化默认页面
             OnStartGame();
+        }
+
+        public async Task CheckForUpdatesAsync()
+        {
+            const string latestReleaseApi = "https://api.github.com/repos/Sjshi763/PicaComic/releases/latest";
+            const string releasesPage = "https://github.com/Sjshi763/PicaComic/releases";
+
+            try
+            {
+                using var client = new HttpClient();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("ATC4-HQ-UpdateChecker");
+
+                var response = await client.GetAsync(latestReleaseApi);
+                if (!response.IsSuccessStatusCode)
+                {
+                    LoggerHelper.LogWarning($"检查更新失败，状态码：{response.StatusCode}");
+                    return;
+                }
+
+                var json = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(json);
+
+                var latestTag = doc.RootElement.GetProperty("tag_name").GetString() ?? string.Empty;
+                var latestVersionText = latestTag.Trim().TrimStart('v', 'V');
+                var currentVersionText = GlobalPaths.Version.Trim().TrimStart('v', 'V');
+
+                if (!Version.TryParse(latestVersionText, out var latestVersion) ||
+                    !Version.TryParse(currentVersionText, out var currentVersion))
+                {
+                    LoggerHelper.LogWarning($"版本号解析失败，当前版本：{GlobalPaths.Version}，远程版本：{latestTag}");
+                    return;
+                }
+
+                if (latestVersion > currentVersion)
+                {
+                    UpdateAvailable?.Invoke(this, new UpdateAvailableEventArgs(GlobalPaths.Version, latestTag, releasesPage));
+                }
+                else
+                {
+                    LoggerHelper.LogInformation($"当前已是最新版本：{GlobalPaths.Version}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogWarning($"检查更新时发生异常：{ex.Message}");
+            }
         }
 
         private void OnStartGame()
@@ -299,6 +350,20 @@ namespace ATC4_HQ.ViewModels
         {
             CurrentSubPage = null;
             LoggerHelper.LogInformation("已清除右边区域的内容。");
+        }
+    }
+
+    public sealed class UpdateAvailableEventArgs : EventArgs
+    {
+        public string CurrentVersion { get; }
+        public string LatestVersion { get; }
+        public string ReleasesPageUrl { get; }
+
+        public UpdateAvailableEventArgs(string currentVersion, string latestVersion, string releasesPageUrl)
+        {
+            CurrentVersion = currentVersion;
+            LatestVersion = latestVersion;
+            ReleasesPageUrl = releasesPageUrl;
         }
     }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -71,6 +71,7 @@ namespace ATC4_HQ.ViewModels
 
             try
             {
+                LoggerHelper.LogInformation($"开始检查更新，当前版本：{GlobalPaths.Version}");
                 using var client = new HttpClient();
                 client.DefaultRequestHeaders.UserAgent.ParseAdd("ATC4-HQ-UpdateChecker");
 
@@ -87,6 +88,7 @@ namespace ATC4_HQ.ViewModels
                 var latestTag = doc.RootElement.GetProperty("tag_name").GetString() ?? string.Empty;
                 var latestVersionText = latestTag.Trim().TrimStart('v', 'V');
                 var currentVersionText = GlobalPaths.Version.Trim().TrimStart('v', 'V');
+                LoggerHelper.LogInformation($"更新检查返回版本信息，当前：{currentVersionText}，远程：{latestVersionText}");
 
                 if (!Version.TryParse(latestVersionText, out var latestVersion) ||
                     !Version.TryParse(currentVersionText, out var currentVersion))
@@ -97,6 +99,7 @@ namespace ATC4_HQ.ViewModels
 
                 if (latestVersion > currentVersion)
                 {
+                    LoggerHelper.LogInformation($"检测到新版本，当前：{GlobalPaths.Version}，最新：{latestTag}，准备通知界面层。");
                     UpdateAvailable?.Invoke(this, new UpdateAvailableEventArgs(GlobalPaths.Version, latestTag, releasesPage));
                 }
                 else

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -13,7 +13,7 @@ using Avalonia;
 using Avalonia.Media;
 using Avalonia.Input;
 using Microsoft.Extensions.Logging;
-using System.Net.Http;
+using System.Diagnostics;
 
 namespace ATC4_HQ.Views
 {
@@ -178,55 +178,11 @@ namespace ATC4_HQ.Views
             GlobalPaths.TransitSoftwareLE = ini.GetSetting("main", "TransitSoftwareLE", string.Empty);
             GlobalPaths.GamePath = ini.GetSetting("main", "GamePath", string.Empty);
 
-            await CheckForUpdatesAsync();
-
-        }
-
-        private async Task CheckForUpdatesAsync()
-        {
-            const string latestReleaseApi = "https://api.github.com/repos/Sjshi763/PicaComic/releases/latest";
-            const string releasesPage = "https://github.com/Sjshi763/PicaComic/releases";
-
-            try
+            if (DataContext is MainWindowViewModel viewModel)
             {
-                using var client = new HttpClient();
-                client.DefaultRequestHeaders.UserAgent.ParseAdd("ATC4-HQ-UpdateChecker");
-
-                var response = await client.GetAsync(latestReleaseApi);
-                if (!response.IsSuccessStatusCode)
-                {
-                    LoggerHelper.LogWarning($"检查更新失败，状态码：{response.StatusCode}");
-                    return;
-                }
-
-                var json = await response.Content.ReadAsStringAsync();
-                using var doc = JsonDocument.Parse(json);
-
-                var latestTag = doc.RootElement.GetProperty("tag_name").GetString() ?? string.Empty;
-                var latestVersionText = latestTag.Trim().TrimStart('v', 'V');
-                var currentVersionText = GlobalPaths.Version.Trim().TrimStart('v', 'V');
-
-                if (!Version.TryParse(latestVersionText, out var latestVersion) ||
-                    !Version.TryParse(currentVersionText, out var currentVersion))
-                {
-                    LoggerHelper.LogWarning($"版本号解析失败，当前版本：{GlobalPaths.Version}，远程版本：{latestTag}");
-                    return;
-                }
-
-                if (latestVersion > currentVersion)
-                {
-                    ShowMessageDialog(this,
-                        $"发现新版本\n当前版本：{GlobalPaths.Version}\n最新版本：{latestTag}\n请前往下载：{releasesPage}");
-                }
-                else
-                {
-                    LoggerHelper.LogInformation($"当前已是最新版本：{GlobalPaths.Version}");
-                }
+                await viewModel.CheckForUpdatesAsync();
             }
-            catch (Exception ex)
-            {
-                LoggerHelper.LogWarning($"检查更新时发生异常：{ex.Message}");
-            }
+
         }
 
         private void PrimaryProfile()
@@ -269,6 +225,33 @@ namespace ATC4_HQ.Views
             if (DataContext is MainWindowViewModel viewModel)
             {
                 viewModel.ShowOpenALInstallView += OnShowOpenALInstallView;
+                viewModel.UpdateAvailable += OnUpdateAvailable;
+            }
+        }
+
+        private async void OnUpdateAvailable(object? sender, UpdateAvailableEventArgs e)
+        {
+            var shouldUpdate = await ShowConfirmDialog(
+                this,
+                "发现新版本",
+                $"当前版本：{e.CurrentVersion}\n最新版本：{e.LatestVersion}\n是否前往更新页面？");
+
+            if (!shouldUpdate)
+            {
+                return;
+            }
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = e.ReleasesPageUrl,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogWarning($"打开更新页面失败：{ex.Message}");
             }
         }
         
@@ -369,6 +352,48 @@ namespace ATC4_HQ.Views
             
             // 显示对话框
             await resultWindow.ShowDialog(parentWindow);
+        }
+
+        private async Task<bool> ShowConfirmDialog(Window parentWindow, string title, string message)
+        {
+            var dialogWindow = new Window
+            {
+                Title = title,
+                Width = 450,
+                Height = 220,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                CanResize = false
+            };
+
+            var stackPanel = new StackPanel { Margin = new Thickness(20) };
+            stackPanel.Children.Add(new TextBlock
+            {
+                Text = message,
+                FontSize = 16,
+                TextWrapping = TextWrapping.Wrap,
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 20)
+            });
+
+            var buttonsPanel = new StackPanel
+            {
+                Orientation = Avalonia.Layout.Orientation.Horizontal,
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                Spacing = 12
+            };
+
+            var noButton = new Button { Content = "暂不更新", Width = 100, Height = 35 };
+            var yesButton = new Button { Content = "前往更新", Width = 100, Height = 35 };
+
+            noButton.Click += (_, __) => dialogWindow.Close(false);
+            yesButton.Click += (_, __) => dialogWindow.Close(true);
+
+            buttonsPanel.Children.Add(noButton);
+            buttonsPanel.Children.Add(yesButton);
+            stackPanel.Children.Add(buttonsPanel);
+
+            dialogWindow.Content = stackPanel;
+            return await dialogWindow.ShowDialog<bool>(parentWindow);
         }
         
         /// <summary>

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -13,6 +13,7 @@ using Avalonia;
 using Avalonia.Media;
 using Avalonia.Input;
 using Microsoft.Extensions.Logging;
+using System.Net.Http;
 
 namespace ATC4_HQ.Views
 {
@@ -177,6 +178,55 @@ namespace ATC4_HQ.Views
             GlobalPaths.TransitSoftwareLE = ini.GetSetting("main", "TransitSoftwareLE", string.Empty);
             GlobalPaths.GamePath = ini.GetSetting("main", "GamePath", string.Empty);
 
+            await CheckForUpdatesAsync();
+
+        }
+
+        private async Task CheckForUpdatesAsync()
+        {
+            const string latestReleaseApi = "https://api.github.com/repos/Sjshi763/PicaComic/releases/latest";
+            const string releasesPage = "https://github.com/Sjshi763/PicaComic/releases";
+
+            try
+            {
+                using var client = new HttpClient();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("ATC4-HQ-UpdateChecker");
+
+                var response = await client.GetAsync(latestReleaseApi);
+                if (!response.IsSuccessStatusCode)
+                {
+                    LoggerHelper.LogWarning($"检查更新失败，状态码：{response.StatusCode}");
+                    return;
+                }
+
+                var json = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(json);
+
+                var latestTag = doc.RootElement.GetProperty("tag_name").GetString() ?? string.Empty;
+                var latestVersionText = latestTag.Trim().TrimStart('v', 'V');
+                var currentVersionText = GlobalPaths.Version.Trim().TrimStart('v', 'V');
+
+                if (!Version.TryParse(latestVersionText, out var latestVersion) ||
+                    !Version.TryParse(currentVersionText, out var currentVersion))
+                {
+                    LoggerHelper.LogWarning($"版本号解析失败，当前版本：{GlobalPaths.Version}，远程版本：{latestTag}");
+                    return;
+                }
+
+                if (latestVersion > currentVersion)
+                {
+                    ShowMessageDialog(this,
+                        $"发现新版本\n当前版本：{GlobalPaths.Version}\n最新版本：{latestTag}\n请前往下载：{releasesPage}");
+                }
+                else
+                {
+                    LoggerHelper.LogInformation($"当前已是最新版本：{GlobalPaths.Version}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogWarning($"检查更新时发生异常：{ex.Message}");
+            }
         }
 
         private void PrimaryProfile()

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -231,10 +231,15 @@ namespace ATC4_HQ.Views
 
         private async void OnUpdateAvailable(object? sender, UpdateAvailableEventArgs e)
         {
+            LoggerHelper.LogInformation($"收到更新通知事件，当前版本：{e.CurrentVersion}，最新版本：{e.LatestVersion}");
             var shouldUpdate = await ShowConfirmDialog(
                 this,
                 "发现新版本",
                 $"当前版本：{e.CurrentVersion}\n最新版本：{e.LatestVersion}\n是否前往更新页面？");
+
+            LoggerHelper.LogInformation(shouldUpdate
+                ? "用户选择前往更新页面。"
+                : "用户选择暂不更新。");
 
             if (!shouldUpdate)
             {
@@ -243,11 +248,13 @@ namespace ATC4_HQ.Views
 
             try
             {
+                LoggerHelper.LogInformation($"正在打开更新页面：{e.ReleasesPageUrl}");
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = e.ReleasesPageUrl,
                     UseShellExecute = true
                 });
+                LoggerHelper.LogInformation("更新页面已发起打开请求。");
             }
             catch (Exception ex)
             {

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -173,13 +173,16 @@ namespace ATC4_HQ.Views
             if (PrimaryProfileVersion != GlobalPaths.Version)
             {
                 LoggerHelper.LogWarning($"配置文件版本不匹配，当前版本：{GlobalPaths.Version}，配置文件版本：{PrimaryProfileVersion}");
-                return;
+                LoggerHelper.LogInformation("继续执行启动流程，并使用当前程序版本更新配置文件中的 Version 字段。");
+                ini.SetSetting("main", "Version", GlobalPaths.Version);
+                ini.Save(GlobalPaths.InitiatorProfileName);
             }
             GlobalPaths.TransitSoftwareLE = ini.GetSetting("main", "TransitSoftwareLE", string.Empty);
             GlobalPaths.GamePath = ini.GetSetting("main", "GamePath", string.Empty);
 
             if (DataContext is MainWindowViewModel viewModel)
             {
+                LoggerHelper.LogInformation("准备调用 ViewModel.CheckForUpdatesAsync() 执行更新检测。");
                 await viewModel.CheckForUpdatesAsync();
             }
 


### PR DESCRIPTION
### Motivation

- Replace the manually maintained `GlobalPaths.Version` constant with build-embedded metadata so runtime update checks compare against the real released build.
- Make released artifacts and installer/MSI carry the release tag as assembly/file/informational version to avoid version drift and simplify release automation.

### Description

- Changed `GlobalPaths.Version` in `Globals.cs` to `GetAppVersion()` which reads `AssemblyInformationalVersionAttribute` first and falls back to the assembly `Version` at runtime.
- Updated `.github/workflows/main.yml` to export `RELEASE_TAG`, extract a cleaned `APP_VERSION` (stripping leading `v/V`), and set `APP_VERSION` into the environment for the job.
- Injected `/p:Version`, `/p:AssemblyVersion`, `/p:FileVersion`, and `/p:InformationalVersion` into `dotnet build` and `dotnet publish` so the produced executable/publish output contains the release tag value.
- Kept existing startup update check behavior (it now reads `GlobalPaths.Version` from assembly metadata) so UI notifications continue to work with the embedded version.

### Testing

- Attempted a local `dotnet build` but the environment lacks the .NET SDK so the build could not be executed here.
- No automated CI runs were executed in this environment, but the workflow is configured to run on GitHub `release` events and will embed the release tag into the build when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141f69bed083249a2cf040b9ff1f3f)

## Summary by Sourcery

在应用程序和 CI 构建输出中嵌入发布标签版本元数据，并添加基于 GitHub Releases 的运行时更新检查。

New Features:
- 添加在启动时基于 GitHub 的更新检查功能，对比当前运行的应用版本与最新发布版本，并在有可用更新时通知用户。

Enhancements:
- 通过辅助方法从程序集元数据中派生全局应用版本，而不是使用硬编码常量，从而使运行时版本与构建输出保持一致。

CI:
- 在 GitHub Actions 工作流中导出发布标签信息，推导出应用版本，并将其注入到 dotnet build/publish 的版本属性中，使构建产物携带发布版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed release tag version metadata into the app and CI build outputs, and add a runtime update check against GitHub releases.

New Features:
- Add a startup GitHub-based update check that compares the running app version with the latest release and notifies users when an update is available.

Enhancements:
- Derive the global app version from assembly metadata via a helper rather than a hardcoded constant to align runtime versioning with build outputs.

CI:
- Export release tag information in the GitHub Actions workflow, derive an application version, and inject it into dotnet build/publish version properties so artifacts carry the release version.

</details>