### PR TITLE
feat(settings): 在设置中新增快速打开日志目录

### DIFF
--- a/ViewModels/SettingViewModel.cs
+++ b/ViewModels/SettingViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Windows.Input;
@@ -59,6 +60,31 @@ public partial class SettingViewModel : ViewModelBase
         _ini.SetSetting("main", "TransitSoftwareLE", GlobalPaths.TransitSoftwareLE ?? string.Empty);
         _ini.Save(GlobalPaths.InitiatorProfileName);
         LoggerHelper.LogInformation($"设置已保存。{GlobalPaths.TransitSoftwareLE}");
+    }
+
+
+    public ICommand OpenLogCommand => new RelayCommand(OpenLogDirectory);
+
+    private void OpenLogDirectory()
+    {
+        try
+        {
+            if (!Directory.Exists(GlobalPaths.LogPath))
+            {
+                Directory.CreateDirectory(GlobalPaths.LogPath);
+            }
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = GlobalPaths.LogPath,
+                UseShellExecute = true
+            });
+            LoggerHelper.LogInformation($"已打开日志目录：{GlobalPaths.LogPath}");
+        }
+        catch (Exception ex)
+        {
+            LoggerHelper.LogError($"打开日志目录失败：{ex.Message}");
+        }
     }
 
     public IAsyncRelayCommand BrowseLECommand => new AsyncRelayCommand(async () => 

--- a/Views/Setting.axaml
+++ b/Views/Setting.axaml
@@ -14,6 +14,10 @@
 			<Label Grid.Row="0" Grid.Column="0">LE位置</Label>
 			<TextBox Grid.Row="0" Text="{Binding LE_address, Mode=TwoWay}" Grid.Column="1" Width="300" Margin="0,0,0,0" />
 			<Button Grid.Row="0" Grid.Column="2" Content="浏览" Margin="5,0,0,0" Command="{Binding BrowseLECommand}"/>
+
+			<Label Grid.Row="1" Grid.Column="0">日志</Label>
+			<TextBlock Grid.Row="1" Grid.Column="1" Text="快速打开日志目录" VerticalAlignment="Center" />
+			<Button Grid.Row="1" Grid.Column="2" Content="打开" Margin="5,0,0,0" Command="{Binding OpenLogCommand}"/>
 		</Grid>
 		<Grid Grid.Row="1">
 			<Button HorizontalAlignment="Center" Margin="5" Command="{Binding SaveSettingCommand}">保存</Button>


### PR DESCRIPTION
### Motivation
- 提供一个在设置界面中一键打开日志目录的快捷操作，方便用户查看运行日志。

### Description
- 在 `Views/Setting.axaml` 中新增一行“日志”条目，包含描述文本和一个绑定到 `OpenLogCommand` 的“打开”按钮。
- 在 `ViewModels/SettingViewModel.cs` 中新增 `OpenLogCommand` 与 `OpenLogDirectory` 方法，方法会确保 `GlobalPaths.LogPath` 存在并通过系统外壳（`Process.Start` + `UseShellExecute = true`）打开该目录，执行结果会写入日志。 
- 为此引入了 `using System.Diagnostics;` 并在打开失败时记录错误信息。 

### Testing
- 尝试运行 `dotnet build` 以进行编译验证，但当前环境缺少 `dotnet`，构建无法完成（失败）。
- 未运行其它自动化测试或单元测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14244e056883249027c688a745af40)

## 由 Sourcery 提供的摘要

在设置中新增一个选项，可从 UI 快速打开应用程序日志目录。

新功能：
- 在设置视图模型中提供 `OpenLog` 命令，通过操作系统的 Shell 打开应用程序日志目录。
- 在设置界面中为日志目录添加一个带有“打开”操作的条目。

增强点：
- 在打开日志目录之前确保其存在，并记录该操作成功或失败的日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a settings option to quickly open the application log directory from the UI.

New Features:
- Expose an OpenLog command in the settings view model to open the application log directory via the OS shell.
- Add a settings UI entry with an "open" action for the log directory.

Enhancements:
- Ensure the log directory exists before opening it and log the success or failure of the operation.

</details>