### PR TITLE
Add AppPaths resolver for writable application directories

### DIFF
--- a/Globals.cs
+++ b/Globals.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 
 namespace master
@@ -7,14 +6,14 @@ namespace master
     {
         public static class GlobalPaths
         {
-            public static string InitiatorProfileName = @".\ATC4-HQ.ini";
+            public static string InitiatorProfileName = AppPaths.InitiatorProfilePath;
             public static string Version = GetAppVersion();
             public static string? TransitSoftwareLE;
             public static string? FirstRun;
             public static string Keys = "0x5A";
             public static string? GamePath;
             public static string? GameName;
-            public static string LogPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ATC4-HQ", "logs");
+            public static string LogPath = AppPaths.LogDirectory;
 
             private static string GetAppVersion()
             {

--- a/Path.cs
+++ b/Path.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+
+namespace master.Globals
+{
+    /// <summary>
+    /// Provides a single place to resolve application-owned writable paths.
+    ///
+    /// Portable/debug runs keep common files next to the application (./). MSI-style
+    /// installs are commonly placed under Program Files where normal users cannot
+    /// write, so common files are redirected to %APPDATA%\ATC4-HQ.
+    /// </summary>
+    public static class AppPaths
+    {
+        private const string AppFolderName = "ATC4-HQ";
+
+        /// <summary>
+        /// Directory used for logs, configuration and other application-owned files.
+        /// </summary>
+        public static string CommonDirectory { get; } = ResolveCommonDirectory();
+
+        /// <summary>
+        /// Full path to the primary ini profile.
+        /// </summary>
+        public static string InitiatorProfilePath => System.IO.Path.Combine(CommonDirectory, "ATC4-HQ.ini");
+
+        /// <summary>
+        /// Full path to the log directory.
+        /// </summary>
+        public static string LogDirectory => System.IO.Path.Combine(CommonDirectory, "logs");
+
+        private static string ResolveCommonDirectory()
+        {
+            var localDirectory = AppContext.BaseDirectory;
+
+            if (!IsMsiStyleInstallDirectory(localDirectory) && CanWriteToDirectory(localDirectory))
+            {
+                return localDirectory;
+            }
+
+            return System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                AppFolderName);
+        }
+
+        private static bool IsMsiStyleInstallDirectory(string directory)
+        {
+            var normalizedDirectory = System.IO.Path.GetFullPath(directory)
+                .TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+
+            return IsUnderSpecialFolder(normalizedDirectory, Environment.SpecialFolder.ProgramFiles)
+                   || IsUnderSpecialFolder(normalizedDirectory, Environment.SpecialFolder.ProgramFilesX86);
+        }
+
+        private static bool IsUnderSpecialFolder(string directory, Environment.SpecialFolder specialFolder)
+        {
+            var specialFolderPath = Environment.GetFolderPath(specialFolder);
+            if (string.IsNullOrWhiteSpace(specialFolderPath))
+            {
+                return false;
+            }
+
+            var normalizedSpecialFolderPath = System.IO.Path.GetFullPath(specialFolderPath)
+                .TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+
+            return directory.Equals(normalizedSpecialFolderPath, StringComparison.OrdinalIgnoreCase)
+                   || directory.StartsWith(
+                       normalizedSpecialFolderPath + System.IO.Path.DirectorySeparatorChar,
+                       StringComparison.OrdinalIgnoreCase)
+                   || directory.StartsWith(
+                       normalizedSpecialFolderPath + System.IO.Path.AltDirectorySeparatorChar,
+                       StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool CanWriteToDirectory(string directory)
+        {
+            try
+            {
+                Directory.CreateDirectory(directory);
+                var testFile = System.IO.Path.Combine(directory, $".write-test-{Guid.NewGuid():N}.tmp");
+                File.WriteAllText(testFile, string.Empty);
+                File.Delete(testFile);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure logs, configuration and other application-owned files are placed in a writable location when the app is installed to protected locations (e.g. Program Files) while keeping files next to the app for portable/debug runs.

### Description
- Add `Path.cs` implementing `master.Globals.AppPaths` which exposes `CommonDirectory`, `InitiatorProfilePath` and `LogDirectory` and resolves the correct writable directory at runtime.
- `AppPaths` chooses `AppContext.BaseDirectory` when it is writable and not under Program Files, otherwise it falls back to `%APPDATA%\ATC4-HQ` and exposes that to the rest of the code.
- Add helpers `IsMsiStyleInstallDirectory`, `IsUnderSpecialFolder` and `CanWriteToDirectory` to detect MSI-style installs and to perform a write test before selecting a directory.
- Update `Globals.cs` to use `AppPaths.InitiatorProfilePath` for the ini path and `AppPaths.LogDirectory` for logs so all code uses the single resolver.

### Testing
- Attempted to build with `dotnet build ATC4-HQ.sln`, but the command failed in this environment because `dotnet` is not installed (build could not be executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2074f81d888324991278e5852739b4)

## Summary by Sourcery

引入一个用于可写应用程序目录的集中解析器，并更新全局路径以使用该解析器。

新功能：
- 添加 `AppPaths` 辅助类，根据当前安装环境提供用于配置和日志的常用可写目录。

增强内容：
- 通过新的 `AppPaths` 解析器路由 ini 配置文件和日志路径，以同时支持便携式/调试安装和 MSI 风格安装。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a centralized resolver for writable application directories and update global paths to use it.

New Features:
- Add an AppPaths helper class that exposes common writable directories for configuration and logs based on the current installation context.

Enhancements:
- Route ini profile and log paths through the new AppPaths resolver to support both portable/debug and MSI-style installations.

</details>