### PR TITLE
添加快速打开配置文件和游戏配置文件目录的功能，优化设置界面

### DIFF
--- a/ViewModels/SettingViewModel.cs
+++ b/ViewModels/SettingViewModel.cs
@@ -14,26 +14,51 @@ public partial class SettingViewModel : ViewModelBase
     private MainWindowViewModel _mainWindowViewModel;
 
     public ICommand OpenLogCommand => new RelayCommand(OpenLogDirectory);
+    public ICommand OpenConfigDirectoryCommand => new RelayCommand(OpenConfigDirectory);
+    public ICommand OpenGameConfigDirectoryCommand => new RelayCommand(OpenGameConfigDirectory);
 
     private void OpenLogDirectory()
     {
+        OpenDirectory(GlobalPaths.LogPath, "日志目录");
+    }
+
+    private void OpenConfigDirectory()
+    {
+        var configDirectory = Path.GetDirectoryName(GlobalPaths.InitiatorProfileName) ?? AppPaths.CommonDirectory;
+        OpenDirectory(configDirectory, "配置文件目录");
+    }
+
+    private void OpenGameConfigDirectory()
+    {
+        var gameDirectory = GlobalPaths.CurrentGame?.Path;
+        if (string.IsNullOrWhiteSpace(gameDirectory))
+        {
+            LoggerHelper.LogWarning("打开游戏配置文件目录失败：当前未选择游戏。");
+            return;
+        }
+
+        OpenDirectory(gameDirectory, "游戏配置文件目录");
+    }
+
+    private static void OpenDirectory(string directoryPath, string displayName)
+    {
         try
         {
-            if (!Directory.Exists(GlobalPaths.LogPath))
+            if (!Directory.Exists(directoryPath))
             {
-                Directory.CreateDirectory(GlobalPaths.LogPath);
+                Directory.CreateDirectory(directoryPath);
             }
 
             Process.Start(new ProcessStartInfo
             {
-                FileName = GlobalPaths.LogPath,
+                FileName = directoryPath,
                 UseShellExecute = true
             });
-            LoggerHelper.LogInformation($"已打开日志目录：{GlobalPaths.LogPath}");
+            LoggerHelper.LogInformation($"已打开{displayName}：{directoryPath}");
         }
         catch (Exception ex)
         {
-            LoggerHelper.LogError($"打开日志目录失败：{ex.Message}");
+            LoggerHelper.LogError($"打开{displayName}失败：{ex.Message}");
         }
     }
 }

--- a/Views/Setting.axaml
+++ b/Views/Setting.axaml
@@ -7,11 +7,19 @@
              x:Class="ATC4_HQ.Views.Setting"
              x:DataType="viewModels:SettingViewModel">
     <Grid Margin="5"
-          ColumnDefinitions="100, 350, 50"
-          RowDefinitions="Auto"
+          ColumnDefinitions="120, 350, 50"
+          RowDefinitions="Auto,Auto,Auto"
           HorizontalAlignment="Left">
         <Label Grid.Row="0" Grid.Column="0">日志</Label>
         <TextBlock Grid.Row="0" Grid.Column="1" Text="快速打开日志目录" VerticalAlignment="Center" />
         <Button Grid.Row="0" Grid.Column="2" Content="打开" Margin="5,0,0,0" Command="{Binding OpenLogCommand}"/>
+
+        <Label Grid.Row="1" Grid.Column="0" Margin="0,6,0,0">配置文件</Label>
+        <TextBlock Grid.Row="1" Grid.Column="1" Text="快速打开配置文件目录" VerticalAlignment="Center" Margin="0,6,0,0" />
+        <Button Grid.Row="1" Grid.Column="2" Content="打开" Margin="5,6,0,0" Command="{Binding OpenConfigDirectoryCommand}"/>
+
+        <Label Grid.Row="2" Grid.Column="0" Margin="0,6,0,0">游戏配置文件</Label>
+        <TextBlock Grid.Row="2" Grid.Column="1" Text="快速打开当前游戏配置文件目录" VerticalAlignment="Center" Margin="0,6,0,0" />
+        <Button Grid.Row="2" Grid.Column="2" Content="打开" Margin="5,6,0,0" Command="{Binding OpenGameConfigDirectoryCommand}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary by Sourcery

在设置视图模型中新增命令，可快速打开日志、应用配置和游戏配置目录，并集中目录打开逻辑，实现统一的日志记录。

新功能：
- 在设置界面中暴露命令，用于打开应用程序配置目录和当前游戏的配置目录。

改进：
- 将打开目录的逻辑重构为可复用的辅助工具，通过可自定义的目录标签记录成功和失败日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add commands to quickly open log, app configuration, and game configuration directories from the settings view model and centralize directory opening logic with unified logging.

New Features:
- Expose commands to open the application configuration directory and the current game's configuration directory from the settings screen.

Enhancements:
- Refactor directory opening into a reusable helper that logs success and failure with customizable directory labels.

</details>